### PR TITLE
Add basic GitHub action for running maven build and test

### DIFF
--- a/.github/workflows/maven-package.yml
+++ b/.github/workflows/maven-package.yml
@@ -1,0 +1,30 @@
+# This workflow will build a Java project with Maven, and cache/restore any dependencies to improve the workflow execution time
+# For more information see: https://help.github.com/actions/language-and-framework-guides/building-and-testing-java-with-maven
+
+name: Maven build
+
+on:
+  push:
+  pull_request:
+    branches: [ "main" ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Code checkout
+        uses: actions/checkout@v3
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v3
+        with:
+          java-version: '17'
+          distribution: 'temurin'
+          cache: maven
+
+      - name: Build
+        run: mvn --batch-mode --threads 2C -DskipTests package
+
+      - name: Test
+        run: mvn --batch-mode --threads 2C -Dmaven.test.failure.ignore=true test

--- a/.github/workflows/maven-package.yml
+++ b/.github/workflows/maven-package.yml
@@ -27,4 +27,4 @@ jobs:
         run: mvn --batch-mode --threads 2C -DskipTests package
 
       - name: Test
-        run: mvn --batch-mode --threads 2C -Dmaven.test.failure.ignore=true test
+        run: mvn --batch-mode --threads 2C test


### PR DESCRIPTION
This change adds a GitHub pipeline that runs a Maven build and JUnit tests to ensure that builds are green before code is merged. This should help prevent any contributions accidentally introducing issues.

Notes:
- It runs on all pushes and again on merge request creation (since the target branch may be ahead)
- It uses `ubuntu:latest` and JDK 17. From getting this running on my Pi 4B on 22.04.1 LTS this has worked just fine, and JDK 16 that is currently being used is [no longer supported](https://www.oracle.com/java/technologies/java-se-support-roadmap.html) so it's a good time to encourage moving away from it.
- It doesn't yet report the details of test failures back to GitHub but [actions exist to do that](https://github.com/marketplace/actions/junit-report-action) - I just haven't tested them and wanted to get something simple merged first.

Having a build/test pipeline is a prerequisite to introducing something like Dependabot to automatically keep dependencies up-to-date - we don't want to accidentally merge dependency bumps that break the build :smile:   

Edit:

Oops, forgot to say - you can see evidence that this works [here](https://github.com/mfoo/lumicube-daemon/tree/build-and-test-pipeline):
- See the :heavy_check_mark: to the right of the most recent commit message
- Click the check mark or go to Actions to [see the run itself](https://github.com/mfoo/lumicube-daemon/actions/runs/3133645743)
- Click on "Build" on that page to [see the build output](https://github.com/mfoo/lumicube-daemon/actions/runs/3133645743/jobs/5087251025).