### PR TITLE
Add dependencies to Daemon jar with maven-jar-plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -38,6 +38,24 @@
 							<goal>single</goal>
 						</goals>
 					</execution>
+					<execution>
+						<phase>package</phase>
+						<goals>
+							<goal>single</goal>
+						</goals>
+						<configuration>
+							<archive>
+								<manifest>
+									<mainClass>
+										com.abstractfoundry.daemon.Daemon
+									</mainClass>
+								</manifest>
+							</archive>
+							<descriptorRefs>
+								<descriptorRef>jar-with-dependencies</descriptorRef>
+							</descriptorRefs>
+						</configuration>
+					</execution>
 				</executions>
 			</plugin>
 		</plugins>


### PR DESCRIPTION
This MR modifies the build process to add runtime dependency jars into the `Daemon-<version>.jar` file at build time.

Previously, running the software outside of the AppImage would look like this (assuming you've just run something like `mvn package`):

```
cd target
unzip Daemon-1.3.zip
cd Daemon-1.3
java -cp "lib/*" -Dlogback.configurationFile=log.xml com.abstractfoundry.daemon.Daemon
```

The produced files had these sizes:

```
➜ du -h Daemon-1.3*
7.0M	Daemon-1.3.jar
25M	Daemon-1.3.zip
```

and the jar inside the zip was the same size:

```
➜ unzip -l Daemon-1.3.zip | grep Daemon-1.3.jar
  7269403  2022-09-30 08:03   Daemon-1.3/lib/Daemon-1.3.jar
```

Now, the generated zip in `target` is much larger (about the same as the zip):

```
➜ du -h target/Daemon-1.3.*     
26M	target/Daemon-1.3.jar
25M	target/Daemon-1.3.zip
```

and the jar inside the zip is still the same size:

```
➜  unzip -l Daemon-1.3.zip | grep Daemon-1.3.jar
  7269479  2022-09-30 08:08   Daemon-1.3/lib/Daemon-1.3.jar
```

but I can now run the jar directly with `java -jar` instead of manually providing the classpath and I no longer need to provide the main class:

```
➜ mvn clean -T 2C package > /dev/null          
➜ java -jar target/Daemon-1.3.jar -Dlogback.configurationFile=log.xml                              
Exception in thread "main" com.fazecast.jSerialComm.SerialPortInvalidPortException: Unable to create a serial port object from the invalid port descriptor: /dev/-Dlogback.configurationFile=log.xml
```

I am running this from a laptop, not the pi, so the error is expected. If I tried this before I'd have got classpath resolution errors for the first external class the JVM tried to load.