### PR TITLE
Add the Maven build status to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+![Maven build](https://github.com/abstractfoundry/lumicube-daemon/actions/workflows/maven-package.yml/badge.svg)
+
 # lumicube-daemon
 
 LumiCube service for the Raspberry Pi.


### PR DESCRIPTION
This MR adds a badge showing the Maven build status (of the `main` branch) to the top of the README. It's a bit of low value optional flare - but when you have other badges for build actions like linting and vulnerability scans it can definitely add credence to a project.

[See it in action here](https://github.com/mfoo/lumicube-daemon/tree/build-badge-in-readme). 

Docs: https://docs.github.com/en/actions/monitoring-and-troubleshooting-workflows/adding-a-workflow-status-badge